### PR TITLE
Update calculators for SpellContext

### DIFF
--- a/src/main/java/org/example/calculator/IDamageCalculator.java
+++ b/src/main/java/org/example/calculator/IDamageCalculator.java
@@ -1,7 +1,7 @@
 package org.example.calculator;
 
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 
 public interface IDamageCalculator {
-    double calculateDamage(Spell spell);
+    double calculateDamage(SpellContext context);
 }

--- a/src/main/java/org/example/calculator/IKnockbackCalculator.java
+++ b/src/main/java/org/example/calculator/IKnockbackCalculator.java
@@ -1,8 +1,8 @@
 package org.example.calculator;
 
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 
 public interface IKnockbackCalculator {
 
-    double calculateKnockback(Spell spell, double distance);
+    double calculateKnockback(SpellContext context, double distance);
 }

--- a/src/main/java/org/example/calculator/IMetaCalculator.java
+++ b/src/main/java/org/example/calculator/IMetaCalculator.java
@@ -1,10 +1,11 @@
 package org.example.calculator;
 
 import net.kyori.adventure.text.Component;
+import org.example.context.SpellContext;
 import org.example.spell.Spell;
 
 public interface IMetaCalculator {
 
-    Component getMeta(Spell spell);
+    Component getMeta(SpellContext context);
     boolean supports(Spell spell);
 }

--- a/src/main/java/org/example/calculator/IRangeCalculator.java
+++ b/src/main/java/org/example/calculator/IRangeCalculator.java
@@ -1,8 +1,8 @@
 package org.example.calculator;
 
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 
 public interface IRangeCalculator {
 
-    double calculateRange(Spell spell);
+    double calculateRange(SpellContext context);
 }

--- a/src/main/java/org/example/calculator/MetaExecutor.java
+++ b/src/main/java/org/example/calculator/MetaExecutor.java
@@ -1,6 +1,7 @@
 package org.example.calculator;
 
 import net.kyori.adventure.text.Component;
+import org.example.context.SpellContext;
 import org.example.spell.Spell;
 
 import java.util.List;
@@ -13,11 +14,12 @@ public class MetaExecutor {
         this.calculators = calculators;
     }
 
-    public Component calculateMeta(Spell spell) {
+    public Component calculateMeta(SpellContext context) {
+        Spell spell = context.getSpell();
         return calculators.stream()
                 .filter(calculator -> calculator.supports(spell))
                 .findFirst()
-                .map(calculator -> calculator.getMeta(spell))
+                .map(calculator -> calculator.getMeta(context))
                 .orElse(Component.empty());
     }
 }

--- a/src/main/java/org/example/calculator/fireball/FireballCalculateManager.java
+++ b/src/main/java/org/example/calculator/fireball/FireballCalculateManager.java
@@ -1,6 +1,7 @@
 package org.example.calculator.fireball;
 
 import org.example.calculator.ICalculateManager;
+import org.example.context.SpellContext;
 import org.example.spell.Spell;
 import org.example.spell.frostbolt.FireballSpell;
 
@@ -18,16 +19,16 @@ public class FireballCalculateManager implements ICalculateManager {
         this.fireballRangeCalculator = fireballRangeCalculator;
     }
 
-    public double calculateDamage(Spell spell) {
-        return fireballDamageCalculator.calculateDamage(spell);
+    public double calculateDamage(SpellContext context) {
+        return fireballDamageCalculator.calculateDamage(context);
     }
 
-    public double calculateKnockback(Spell spell, double distance) {
-        return fireballKnockbackCalculator.calculateKnockback(spell, distance);
+    public double calculateKnockback(SpellContext context, double distance) {
+        return fireballKnockbackCalculator.calculateKnockback(context, distance);
     }
 
-    public double calculateRange(Spell spell) {
-        return fireballRangeCalculator.calculateRange(spell);
+    public double calculateRange(SpellContext context) {
+        return fireballRangeCalculator.calculateRange(context);
     }
 
     @Override

--- a/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
@@ -1,13 +1,13 @@
 package org.example.calculator.fireball;
 
 import org.example.calculator.IDamageCalculator;
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 import org.example.spell.frostbolt.FireballSpell;
 
 public class FireballDamageCalculator implements IDamageCalculator {
     @Override
-    public double calculateDamage(Spell spell) {
-        FireballSpell fireballSpell = (FireballSpell) spell;
+    public double calculateDamage(SpellContext context) {
+        FireballSpell fireballSpell = (FireballSpell) context.getSpell();
         int level = fireballSpell.getExperience();
 
         return (double) (5 * level) / (level + 15);

--- a/src/main/java/org/example/calculator/fireball/FireballKnockbackCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballKnockbackCalculator.java
@@ -1,13 +1,13 @@
 package org.example.calculator.fireball;
 
 import org.example.calculator.IKnockbackCalculator;
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 import org.example.spell.frostbolt.FireballSpell;
 
 public class FireballKnockbackCalculator implements IKnockbackCalculator {
     @Override
-    public double calculateKnockback(Spell spell, double distance) {
-        FireballSpell fireballSpell = (FireballSpell) spell;
+    public double calculateKnockback(SpellContext context, double distance) {
+        FireballSpell fireballSpell = (FireballSpell) context.getSpell();
 
         return Math.max(0.2, 1.0 - (distance / fireballSpell.getExplosionRadius()));
     }

--- a/src/main/java/org/example/calculator/fireball/FireballMetaCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballMetaCalculator.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.calculator.IMetaCalculator;
+import org.example.context.SpellContext;
+import org.example.context.SpellContextAttributes;
 import org.example.spell.Spell;
 import org.example.spell.frostbolt.FireballSpell;
 
@@ -16,16 +18,17 @@ public class FireballMetaCalculator implements IMetaCalculator {
     private final FireballCalculateManager fireballCalculateManager;
 
     @Override
-    public Component getMeta(Spell spell) {
+    public Component getMeta(SpellContext context) {
 
-        FireballSpell fireballSpell = (FireballSpell) spell;
+        Double radius = context.getAttr(SpellContextAttributes.EXPLOSION_RADIUS);
+        Double range = context.getAttr(SpellContextAttributes.MAX_RANGE);
 
         return Component.text("\n> Szczegółowe informacje o zaklęciu <", NamedTextColor.GRAY)
                 .hoverEvent(HoverEvent.showText(
                         Component.text("[Szczegółowe informacje parametrów zaklęcia]\n", NamedTextColor.GOLD)
-                                .append(Component.text("- Zasięg eksplozji: ", NamedTextColor.GRAY ).append(Component.text( fireballSpell.getExplosionRadius() + " bloków\n", NamedTextColor.RED))
-                                .append(Component.text("- Obrażenia: ", NamedTextColor.GRAY).append(Component.text(fireballCalculateManager.calculateDamage(fireballSpell) / 2.0 + " ❤\n", NamedTextColor.RED))
-                                        .append(Component.text("- Zasięg rzucenia zaklęcia: ", NamedTextColor.GRAY).append(Component.text(fireballCalculateManager.calculateRange(fireballSpell) + " bloków\n", NamedTextColor.RED))
+                                .append(Component.text("- Zasięg eksplozji: ", NamedTextColor.GRAY ).append(Component.text( radius + " bloków\n", NamedTextColor.RED))
+                                .append(Component.text("- Obrażenia: ", NamedTextColor.GRAY).append(Component.text(fireballCalculateManager.calculateDamage(context) / 2.0 + " ❤\n", NamedTextColor.RED))
+                                        .append(Component.text("- Zasięg rzucenia zaklęcia: ", NamedTextColor.GRAY).append(Component.text(range + " bloków\n", NamedTextColor.RED))
                                 )))));
     }
 

--- a/src/main/java/org/example/calculator/fireball/FireballRangeCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballRangeCalculator.java
@@ -1,13 +1,13 @@
 package org.example.calculator.fireball;
 
 import org.example.calculator.IRangeCalculator;
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 import org.example.spell.frostbolt.FireballSpell;
 
 public class FireballRangeCalculator implements IRangeCalculator {
     @Override
-    public double calculateRange(Spell spell) {
-        FireballSpell fireballSpell = (FireballSpell) spell;
+    public double calculateRange(SpellContext context) {
+        FireballSpell fireballSpell = (FireballSpell) context.getSpell();
 
         return fireballSpell.getMaxRange();
     }

--- a/src/main/java/org/example/calculator/meteor/MeteorCalculateManager.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorCalculateManager.java
@@ -3,6 +3,7 @@ package org.example.calculator.meteor;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.calculator.ICalculateManager;
+import org.example.context.SpellContext;
 import org.example.spell.Spell;
 import org.example.spell.meteor.MeteorSpell;
 
@@ -17,12 +18,12 @@ public class MeteorCalculateManager implements ICalculateManager {
         this.meteorKnockbackCalculator = meteorKnockbackCalculator;
     }
 
-    public double calculateDamage(Spell spell) {
-        return meteorDamageCalculator.calculateDamage(spell);
+    public double calculateDamage(SpellContext context) {
+        return meteorDamageCalculator.calculateDamage(context);
     }
 
-    public double calculateKnockback(Spell spell, double distance) {
-        return meteorKnockbackCalculator.calculateKnockback(spell, distance);
+    public double calculateKnockback(SpellContext context, double distance) {
+        return meteorKnockbackCalculator.calculateKnockback(context, distance);
     }
 
     @Override

--- a/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
@@ -1,13 +1,13 @@
 package org.example.calculator.meteor;
 
 import org.example.calculator.IDamageCalculator;
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 import org.example.spell.meteor.MeteorSpell;
 
 public class MeteorDamageCalculator implements IDamageCalculator {
     @Override
-    public double calculateDamage(Spell spell) {
-        MeteorSpell meteorSpell = (MeteorSpell) spell;
+    public double calculateDamage(SpellContext context) {
+        MeteorSpell meteorSpell = (MeteorSpell) context.getSpell();
         int level = meteorSpell.getExperience();
 
         return (double) (5 * level) / (level + 15);

--- a/src/main/java/org/example/calculator/meteor/MeteorKnockbackCalculator.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorKnockbackCalculator.java
@@ -1,13 +1,13 @@
 package org.example.calculator.meteor;
 
 import org.example.calculator.IKnockbackCalculator;
-import org.example.spell.Spell;
+import org.example.context.SpellContext;
 import org.example.spell.meteor.MeteorSpell;
 
 public class MeteorKnockbackCalculator implements IKnockbackCalculator {
     @Override
-    public double calculateKnockback(Spell spell, double distance) {
-        MeteorSpell meteorSpell = (MeteorSpell) spell;
+    public double calculateKnockback(SpellContext context, double distance) {
+        MeteorSpell meteorSpell = (MeteorSpell) context.getSpell();
 
         return Math.max(0.2, 1.0 - (distance / meteorSpell.getEXPLOSION_RADIUS()));
     }

--- a/src/main/java/org/example/calculator/meteor/MeteorMetaCalculator.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorMetaCalculator.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.calculator.IMetaCalculator;
+import org.example.context.SpellContext;
+import org.example.context.SpellContextAttributes;
 import org.example.spell.Spell;
 import org.example.spell.meteor.MeteorSpell;
 
@@ -16,13 +18,13 @@ public class MeteorMetaCalculator implements IMetaCalculator {
     }
 
     @Override
-    public Component getMeta(Spell spell) {
-        MeteorSpell meteorSpell = (MeteorSpell) spell;
+    public Component getMeta(SpellContext context) {
+        Double radius = context.getAttr(SpellContextAttributes.EXPLOSION_RADIUS);
 
         return Component.text("\n> Szczegółowe informacje o zaklęciu <", NamedTextColor.GRAY)
                 .hoverEvent(HoverEvent.showText(
                         Component.text("[Szczegółowe informacje parametrów zaklęcia]\n", NamedTextColor.GOLD)
-                                .append(Component.text("- Zasięg eksplozji: ", NamedTextColor.GRAY ).append(Component.text( meteorSpell.getEXPLOSION_RADIUS() + " bloków\n", NamedTextColor.RED))
+                                .append(Component.text("- Zasięg eksplozji: ", NamedTextColor.GRAY ).append(Component.text( radius + " bloków\n", NamedTextColor.RED))
                 )));
     }
 

--- a/src/main/java/org/example/context/SpellContextAttributes.java
+++ b/src/main/java/org/example/context/SpellContextAttributes.java
@@ -3,5 +3,7 @@ package org.example.context;
 public enum SpellContextAttributes {
     KNOCKBACK,
     ACTUAL_DAMAGE,
-    HIT_LOCATION
+    HIT_LOCATION,
+    EXPLOSION_RADIUS,
+    MAX_RANGE
 }

--- a/src/main/java/org/example/factory/SpellDescriptionFactory.java
+++ b/src/main/java/org/example/factory/SpellDescriptionFactory.java
@@ -2,6 +2,10 @@ package org.example.factory;
 
 import net.kyori.adventure.text.Component;
 import org.example.calculator.MetaExecutor;
+import org.example.context.SpellContext;
+import org.example.context.SpellContextAttributes;
+import org.example.entity.SpellCaster;
+import org.example.entity.SpellTarget;
 import org.example.spell.Spell;
 
 public class SpellDescriptionFactory {
@@ -15,8 +19,23 @@ public class SpellDescriptionFactory {
 
     public Component createSpellDescription(Spell spell) {
 
+        SpellContext context = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
+
+        switch (spell.getId()) {
+            case "FIREBALL" -> {
+                var fb = (org.example.spell.frostbolt.FireballSpell) spell;
+                context.addAttribute(SpellContextAttributes.EXPLOSION_RADIUS, fb.getExplosionRadius());
+                context.addAttribute(SpellContextAttributes.MAX_RANGE, fb.getMaxRange());
+            }
+            case "METEOR" -> {
+                var ms = (org.example.spell.meteor.MeteorSpell) spell;
+                context.addAttribute(SpellContextAttributes.EXPLOSION_RADIUS, ms.getEXPLOSION_RADIUS());
+                context.addAttribute(SpellContextAttributes.MAX_RANGE, ms.getMaxDistance());
+            }
+        }
+
         return spell.getTitle()
                 .append(spell.getContent())
-                .append(metaExecutor.calculateMeta(spell));
+                .append(metaExecutor.calculateMeta(context));
     }
 }


### PR DESCRIPTION
## Summary
- use `SpellContext` in the calculator interfaces
- update Fireball and Meteor calculator implementations
- forward `SpellContext` through CalculateManagers and `MetaExecutor`
- construct a new `SpellContext` in `SpellDescriptionFactory`
- pass spell metadata through `SpellContext` attributes

## Testing
- `./gradlew test -q` *(fails: Permission denied / network)*

------
https://chatgpt.com/codex/tasks/task_e_68722fbe3188832fa8a50656670ddfd5