### PR TITLE
Add UpgradeableSpell interface

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -156,11 +156,9 @@ public class Main extends JavaPlugin implements Listener {
                 return true;
             }
 
-            try {
-                int current = target.getExperience();
-                target.getClass().getMethod("setExperience", int.class)
-                        .invoke(target, current + amount);
-            } catch (Exception e) {
+            if (target instanceof org.example.spell.UpgradeableSpell up) {
+                up.addExperience(amount);
+            } else {
                 sender.sendMessage("Nie można ustawić doświadczenia tego zaklęcia.");
                 return true;
             }

--- a/src/main/java/org/example/spell/UpgradeableSpell.java
+++ b/src/main/java/org/example/spell/UpgradeableSpell.java
@@ -1,0 +1,13 @@
+package org.example.spell;
+
+public interface UpgradeableSpell extends Spell {
+
+    @Override
+    int getExperience();
+
+    void setExperience(int experience);
+
+    default void addExperience(int amount) {
+        setExperience(getExperience() + amount);
+    }
+}

--- a/src/main/java/org/example/spell/frostbolt/FireballSpell.java
+++ b/src/main/java/org/example/spell/frostbolt/FireballSpell.java
@@ -7,8 +7,9 @@ import org.bukkit.entity.Player;
 import org.example.context.DamageType;
 import org.example.spell.AreaSpell;
 import org.example.spell.InterruptibleSpell;
+import org.example.spell.UpgradeableSpell;
 
-public class FireballSpell implements AreaSpell, InterruptibleSpell {
+public class FireballSpell implements AreaSpell, InterruptibleSpell, UpgradeableSpell {
 
     // Parametry lotu fireballa
     double speed = 5.0;    // bloki na tick

--- a/src/main/java/org/example/spell/meteor/MeteorSpell.java
+++ b/src/main/java/org/example/spell/meteor/MeteorSpell.java
@@ -7,8 +7,9 @@ import org.bukkit.entity.Player;
 import org.example.context.DamageType;
 import org.example.spell.AreaSpell;
 import org.example.spell.InterruptibleSpell;
+import org.example.spell.UpgradeableSpell;
 
-public class MeteorSpell implements AreaSpell, InterruptibleSpell {
+public class MeteorSpell implements AreaSpell, InterruptibleSpell, UpgradeableSpell {
 
     private int experience = 5;
     private Component title;

--- a/src/main/java/org/example/spellbook/Spellbook.java
+++ b/src/main/java/org/example/spellbook/Spellbook.java
@@ -2,7 +2,6 @@ package org.example.spellbook;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import java.lang.reflect.Method;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -77,11 +76,8 @@ public class Spellbook {
             for (SpellInfo info : infos) {
                 Spell s = SpellManager.getById(info.id);
                 if (s != null) {
-                    try {
-                        Method m = s.getClass().getMethod("setExperience", int.class);
-                        m.invoke(s, info.exp);
-                    } catch (Exception ignored) {
-                        // spell has no experience setter
+                    if (s instanceof org.example.spell.UpgradeableSpell up) {
+                        up.setExperience(info.exp);
                     }
                     knownSpells.add(s);
                 }


### PR DESCRIPTION
## Summary
- introduce `UpgradeableSpell` interface
- implement it in FireballSpell and MeteorSpell
- avoid reflection when loading spell XP
- use `UpgradeableSpell` for the `spelllevel` command

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68729831760c832f9c56d4ca96c80b7a