### PR TITLE
Ensure damage formulas use spell experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Custom Mobs Plugin
+
+This plugin includes a simple spell leveling system. Damage for fireball and meteor spells is calculated using the following formula:
+
+```
+damage = (5 * experience) / (experience + 15)
+```
+
+Where `experience` is the experience level stored inside each spell instance. As the spell gains experience, the computed damage grows accordingly.

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ publishing {
 dependencies {
     paperweight.paperDevBundle("1.21.6-R0.1-SNAPSHOT")
     compileOnly files("libs/PacketEvents.jar")
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 tasks.withType(JavaCompile) {
@@ -48,4 +49,8 @@ tasks.withType(JavaCompile) {
 
 tasks.withType(Javadoc) {
     options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
@@ -4,6 +4,13 @@ import org.example.calculator.IDamageCalculator;
 import org.example.context.SpellContext;
 import org.example.spell.frostbolt.FireballSpell;
 
+/**
+ * Calculates fireball damage based on the spell's experience level.
+ *
+ * <p>Formula: <code>(5 * exp) / (exp + 15)</code> where {@code exp}
+ * is obtained from the {@link FireballSpell} instance in the context.
+ * Higher experience therefore results in higher damage.</p>
+ */
 public class FireballDamageCalculator implements IDamageCalculator {
     @Override
     public double calculateDamage(SpellContext context) {

--- a/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
@@ -4,6 +4,12 @@ import org.example.calculator.IDamageCalculator;
 import org.example.context.SpellContext;
 import org.example.spell.meteor.MeteorSpell;
 
+/**
+ * Calculates meteor damage based on the spell's experience level.
+ *
+ * <p>Formula: <code>(5 * exp) / (exp + 15)</code> using the experience
+ * from the {@link MeteorSpell} instance contained in the {@link SpellContext}.</p>
+ */
 public class MeteorDamageCalculator implements IDamageCalculator {
     @Override
     public double calculateDamage(SpellContext context) {

--- a/src/test/java/org/example/calculator/fireball/FireballDamageCalculatorTest.java
+++ b/src/test/java/org/example/calculator/fireball/FireballDamageCalculatorTest.java
@@ -1,0 +1,35 @@
+package org.example.calculator.fireball;
+
+import org.example.context.SpellContext;
+import org.example.entity.SpellCaster;
+import org.example.entity.SpellTarget;
+import org.example.spell.frostbolt.FireballSpell;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FireballDamageCalculatorTest {
+
+    @Test
+    void damageIncreasesWithExperience() {
+        FireballSpell spell = new FireballSpell();
+        FireballDamageCalculator calc = new FireballDamageCalculator();
+
+        // low experience
+        spell.setExperience(5);
+        SpellContext ctxLow = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
+        double low = calc.calculateDamage(ctxLow);
+        double expectedLow = (5d * 5) / (5 + 15);
+
+        // high experience
+        spell.setExperience(20);
+        SpellContext ctxHigh = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
+        double high = calc.calculateDamage(ctxHigh);
+        double expectedHigh = (5d * 20) / (20 + 15);
+
+        assertTrue(high > low, "Damage should increase with experience");
+        assertEquals(expectedLow, low);
+        assertEquals(expectedHigh, high);
+    }
+}

--- a/src/test/java/org/example/calculator/meteor/MeteorDamageCalculatorTest.java
+++ b/src/test/java/org/example/calculator/meteor/MeteorDamageCalculatorTest.java
@@ -1,0 +1,33 @@
+package org.example.calculator.meteor;
+
+import org.example.context.SpellContext;
+import org.example.entity.SpellCaster;
+import org.example.entity.SpellTarget;
+import org.example.spell.meteor.MeteorSpell;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MeteorDamageCalculatorTest {
+
+    @Test
+    void damageIncreasesWithExperience() {
+        MeteorSpell spell = new MeteorSpell();
+        MeteorDamageCalculator calc = new MeteorDamageCalculator();
+
+        spell.setExperience(5);
+        SpellContext ctxLow = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
+        double low = calc.calculateDamage(ctxLow);
+        double expectedLow = (5d * 5) / (5 + 15);
+
+        spell.setExperience(30);
+        SpellContext ctxHigh = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
+        double high = calc.calculateDamage(ctxHigh);
+        double expectedHigh = (5d * 30) / (30 + 15);
+
+        assertTrue(high > low, "Damage should increase with experience");
+        assertEquals(expectedLow, low);
+        assertEquals(expectedHigh, high);
+    }
+}


### PR DESCRIPTION
## Summary
- document damage scaling formula
- clarify experience-based calculations in damage calculators
- add unit tests for damage calculators
- enable JUnit 5 for testing

## Testing
- `gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68729c1a94fc832fa8fe8e9ff8b5c17b