### PR TITLE
Add spell XP leveling util and update damage calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # Custom Mobs Plugin
 
-This plugin includes a simple spell leveling system. Damage for fireball and meteor spells is calculated using the following formula:
+This plugin includes a simple spell leveling system based on total experience points (XP).
+Damage for fireball and meteor spells is calculated using the following formula, where `level`
+is derived from XP:
 
 ```
-damage = (5 * experience) / (experience + 15)
+damage = (5 * level) / (level + 15)
 ```
 
-Where `experience` is the experience level stored inside each spell instance. As the spell gains experience, the computed damage grows accordingly.
+The `experience` field on each spell now stores the cumulative XP earned. Levels are computed
+using `SpellExperienceUtil.levelForExperience(xp)`. The utility mirrors Minecraft's experience
+curve:
+
+- Level 1 starts at 7 XP
+- Level 2 starts at 16 XP
+- Level 3 starts at 27 XP
+
+You can check how much XP is required for the next level using `SpellExperienceUtil.xpNeeded(xp)`.

--- a/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
+++ b/src/main/java/org/example/calculator/fireball/FireballDamageCalculator.java
@@ -15,7 +15,7 @@ public class FireballDamageCalculator implements IDamageCalculator {
     @Override
     public double calculateDamage(SpellContext context) {
         FireballSpell fireballSpell = (FireballSpell) context.getSpell();
-        int level = fireballSpell.getExperience();
+        int level = fireballSpell.getLevel();
 
         return (double) (5 * level) / (level + 15);
     }

--- a/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
+++ b/src/main/java/org/example/calculator/meteor/MeteorDamageCalculator.java
@@ -14,7 +14,7 @@ public class MeteorDamageCalculator implements IDamageCalculator {
     @Override
     public double calculateDamage(SpellContext context) {
         MeteorSpell meteorSpell = (MeteorSpell) context.getSpell();
-        int level = meteorSpell.getExperience();
+        int level = meteorSpell.getLevel();
 
         return (double) (5 * level) / (level + 15);
     }

--- a/src/main/java/org/example/spell/UpgradeableSpell.java
+++ b/src/main/java/org/example/spell/UpgradeableSpell.java
@@ -10,4 +10,18 @@ public interface UpgradeableSpell extends Spell {
     default void addExperience(int amount) {
         setExperience(getExperience() + amount);
     }
+
+    /**
+     * Returns the current level derived from the stored experience value.
+     */
+    default int getLevel() {
+        return org.example.util.SpellExperienceUtil.levelForExperience(getExperience());
+    }
+
+    /**
+     * Remaining experience points required to reach the next level.
+     */
+    default int experienceToNextLevel() {
+        return org.example.util.SpellExperienceUtil.xpNeeded(getExperience());
+    }
 }

--- a/src/main/java/org/example/util/SpellExperienceUtil.java
+++ b/src/main/java/org/example/util/SpellExperienceUtil.java
@@ -1,0 +1,62 @@
+package org.example.util;
+
+/**
+ * Utility class for converting spell experience (XP) to levels and back.
+ * <p>
+ * The formulas mirror Minecraft's experience system so that spells can share a
+ * similar progression curve.
+ * </p>
+ */
+public class SpellExperienceUtil {
+
+    /**
+     * Experience needed to reach the start of the given level.
+     */
+    public static int experienceForLevel(int level) {
+        if (level <= 16) {
+            return level * level + 6 * level;
+        } else if (level <= 31) {
+            return (int) (2.5 * level * level - 40.5 * level + 360);
+        } else {
+            return (int) (4.5 * level * level - 162.5 * level + 2220);
+        }
+    }
+
+    /**
+     * Experience required to progress from the given level to the next level.
+     */
+    public static int experienceToNextLevel(int level) {
+        if (level <= 15) {
+            return 2 * level + 7;
+        } else if (level <= 30) {
+            return 5 * level - 38;
+        } else {
+            return 9 * level - 158;
+        }
+    }
+
+    /**
+     * Calculates the level for the given total experience.
+     */
+    public static int levelForExperience(int experience) {
+        int level = 0;
+        int xpForNext = experienceToNextLevel(level);
+        while (experience >= xpForNext) {
+            experience -= xpForNext;
+            level++;
+            xpForNext = experienceToNextLevel(level);
+        }
+        return level;
+    }
+
+    /**
+     * Returns the remaining XP needed to reach the next level from the current
+     * total experience value.
+     */
+    public static int xpNeeded(int currentXP) {
+        int level = levelForExperience(currentXP);
+        int xpIntoCurrent = currentXP - experienceForLevel(level);
+        int xpForNext = experienceToNextLevel(level);
+        return xpForNext - xpIntoCurrent;
+    }
+}

--- a/src/test/java/org/example/calculator/fireball/FireballDamageCalculatorTest.java
+++ b/src/test/java/org/example/calculator/fireball/FireballDamageCalculatorTest.java
@@ -16,17 +16,19 @@ public class FireballDamageCalculatorTest {
         FireballSpell spell = new FireballSpell();
         FireballDamageCalculator calc = new FireballDamageCalculator();
 
-        // low experience
-        spell.setExperience(5);
+        // low total XP
+        spell.setExperience(10);
         SpellContext ctxLow = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
         double low = calc.calculateDamage(ctxLow);
-        double expectedLow = (5d * 5) / (5 + 15);
+        int lowLevel = org.example.util.SpellExperienceUtil.levelForExperience(10);
+        double expectedLow = (5d * lowLevel) / (lowLevel + 15);
 
-        // high experience
-        spell.setExperience(20);
+        // high total XP
+        spell.setExperience(50);
         SpellContext ctxHigh = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
         double high = calc.calculateDamage(ctxHigh);
-        double expectedHigh = (5d * 20) / (20 + 15);
+        int highLevel = org.example.util.SpellExperienceUtil.levelForExperience(50);
+        double expectedHigh = (5d * highLevel) / (highLevel + 15);
 
         assertTrue(high > low, "Damage should increase with experience");
         assertEquals(expectedLow, low);

--- a/src/test/java/org/example/calculator/meteor/MeteorDamageCalculatorTest.java
+++ b/src/test/java/org/example/calculator/meteor/MeteorDamageCalculatorTest.java
@@ -16,15 +16,17 @@ public class MeteorDamageCalculatorTest {
         MeteorSpell spell = new MeteorSpell();
         MeteorDamageCalculator calc = new MeteorDamageCalculator();
 
-        spell.setExperience(5);
+        spell.setExperience(15);
         SpellContext ctxLow = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
         double low = calc.calculateDamage(ctxLow);
-        double expectedLow = (5d * 5) / (5 + 15);
+        int lowLevel = org.example.util.SpellExperienceUtil.levelForExperience(15);
+        double expectedLow = (5d * lowLevel) / (lowLevel + 15);
 
-        spell.setExperience(30);
+        spell.setExperience(60);
         SpellContext ctxHigh = new SpellContext(spell, new SpellTarget(), new SpellCaster(), 0);
         double high = calc.calculateDamage(ctxHigh);
-        double expectedHigh = (5d * 30) / (30 + 15);
+        int highLevel = org.example.util.SpellExperienceUtil.levelForExperience(60);
+        double expectedHigh = (5d * highLevel) / (highLevel + 15);
 
         assertTrue(high > low, "Damage should increase with experience");
         assertEquals(expectedLow, low);

--- a/src/test/java/org/example/util/SpellExperienceUtilTest.java
+++ b/src/test/java/org/example/util/SpellExperienceUtilTest.java
@@ -1,0 +1,23 @@
+package org.example.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpellExperienceUtilTest {
+
+    @Test
+    void levelAndXpConversions() {
+        // level thresholds
+        assertEquals(0, SpellExperienceUtil.levelForExperience(0));
+        assertEquals(1, SpellExperienceUtil.levelForExperience(7));
+        assertEquals(2, SpellExperienceUtil.levelForExperience(16));
+
+        // experience needed to next level
+        int xp = 20;
+        int level = SpellExperienceUtil.levelForExperience(xp);
+        int remaining = SpellExperienceUtil.xpNeeded(xp);
+        int nextThreshold = SpellExperienceUtil.experienceForLevel(level + 1);
+        assertEquals(nextThreshold - xp, remaining);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpellExperienceUtil` with XP↔level conversions
- expose `getLevel()` and `experienceToNextLevel()` on `UpgradeableSpell`
- use level in damage calculators
- update tests for XP values and add new util tests
- document new XP-based leveling in README

## Testing
- `gradle test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c50fa8d0832fb1b2bc7852e9afc5