### PR TITLE
Improve feedback when granting spell XP

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -156,8 +156,12 @@ public class Main extends JavaPlugin implements Listener {
                 return true;
             }
 
+            int level;
+            int remaining;
             if (target instanceof org.example.spell.UpgradeableSpell up) {
                 up.addExperience(amount);
+                level = up.getLevel();
+                remaining = up.experienceToNextLevel();
             } else {
                 sender.sendMessage("Nie można ustawić doświadczenia tego zaklęcia.");
                 return true;
@@ -165,7 +169,8 @@ public class Main extends JavaPlugin implements Listener {
 
             ExperienceUtil.setTotalExperience(p, totalXp - amount);
             spellManager.saveSpellbookFor(p);
-            sender.sendMessage("Dodano " + amount + " XP do zaklęcia " + spellId + ".");
+            sender.sendMessage("Dodano " + amount + " XP do zaklęcia " + spellId +
+                    ". Poziom: " + level + " (do następnego potrzeba " + remaining + " XP).");
             return true;
         });
     }


### PR DESCRIPTION
## Summary
- compute current level and remaining XP after adding spell experience
- show this information in `/spelllevel` feedback

## Testing
- `gradle test --offline` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c8f24270832faa2cb5c0d970363a