### PR TITLE
Fix knockback normalization

### DIFF
--- a/src/main/java/org/example/handler/fireball/FireballApplyKnockbackHandlerCasting.java
+++ b/src/main/java/org/example/handler/fireball/FireballApplyKnockbackHandlerCasting.java
@@ -27,7 +27,12 @@ public class FireballApplyKnockbackHandlerCasting implements CastingPipelineHand
         Vector sourceVec = impactLoc.toVector();
 
         // Wektor od CELU do ŹRÓDŁA (odwrotnie niż wcześniej)
-        Vector direction = sourceVec.subtract(targetVec).normalize();
+        Vector direction = sourceVec.subtract(targetVec);
+        // Avoid zero-length vectors which would cause an exception on normalize
+        if (direction.lengthSquared() == 0) {
+            return;
+        }
+        direction.normalize();
 
         double strength = context.getAttr(SpellContextAttributes.KNOCKBACK);
 

--- a/src/main/java/org/example/handler/meteor/MeteorApplyKnockbackHandlerCasting.java
+++ b/src/main/java/org/example/handler/meteor/MeteorApplyKnockbackHandlerCasting.java
@@ -27,7 +27,12 @@ public class MeteorApplyKnockbackHandlerCasting implements CastingPipelineHandle
         Vector sourceVec = impactLoc.toVector();
 
         // Wektor od CELU do ŹRÓDŁA (odwrotnie niż wcześniej)
-        Vector direction = sourceVec.subtract(targetVec).normalize();
+        Vector direction = sourceVec.subtract(targetVec);
+        // Avoid zero-length vectors which would cause an exception on normalize
+        if (direction.lengthSquared() == 0) {
+            return;
+        }
+        direction.normalize();
 
         double strength = context.getAttr(SpellContextAttributes.KNOCKBACK);
 


### PR DESCRIPTION
## Summary
- avoid normalizing zero-length vectors when applying knockback for Fireball and Meteor

## Testing
- `./gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68753bb060e8832fb5272ecafb9a77b4